### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ UberBuilder is a set of convenience methods provided to make building flexible, 
 
 - iOS 7.0+ / Mac OS X 10.10+
 - Xcode 6.0
-- Cocoapods 0.37.1
+- CocoaPods 0.37.1
 
-## Cocoapods Installation
+## CocoaPods Installation
 
 1. Add UberBuilder as a line in your Podfile `pod 'UberBuilder/Core', '~> 1.0'`
 2. Run `pod install`


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
